### PR TITLE
fixed a bug in count_users in case of 0 provided keys

### DIFF
--- a/lib/count_users.py
+++ b/lib/count_users.py
@@ -18,6 +18,10 @@ def count_users(diagnosis_key_list, multiplier=10, auto_multiplier_detect=False,
     if len(diagnosis_key_list) > 0:
         latest_interval = max(dk.start_interval for dk in diagnosis_key_list)
         min_interval = latest_interval - 14*144
+    else:
+        # no keys provided, skip user count
+        print("%d user(s) found." % 0)
+        return
 
     if not new_android_apps_only:
         search_range = [0, 1]


### PR DESCRIPTION
Starting from today, the CWA server provides hourly packages that are empty ([Example](https://svc90.main.px.t-online.de/version/v1/diagnosis-keys/country/DE/date/2020-08-07/hour/2); no diagnosis keys provided, only the signature). This PR fixes a bug in the count_users function with zero keys provided which leads to the following crash.

I'd like to keep the exact output ("N user(s) found.") instead of a notification like "No users found", since I grep for this string in my dashboard scripts. :-)

Best regards,
Michael

```
Exposure Notification Diagnosis Key Parser
This script parses published Diagnosis Keys.

File '2' read.
- Time window: 2020-08-07 04:00:00 CEST - 2020-08-07 05:00:00 CEST
- Region: DE
- Batch: 1 of 1
- Signature Info:
verification_key_version: "v1"
verification_key_id: "262"
signature_algorithm: "1.2.840.10045.4.3.2"

Diagnosis Keys:
(none)

Revised Diagnosis Keys:
(none)
Parsing the Diagnosis Key list, counting unique users...
Length: 0 keys (0 without padding)
Traceback (most recent call last):
  File "/home/michael/coding/diagnosis-keys/parse_keys.py", line 227, in <module>
    new_android_apps_only = args.new_android_apps_only)
  File "/home/michael/coding/diagnosis-keys/lib/count_users.py", line 97, in count_users
    latest_interval -= 144
UnboundLocalError: local variable 'latest_interval' referenced before assignment
```

Behavior after applying this fix:
```
Exposure Notification Diagnosis Key Parser
This script parses published Diagnosis Keys.

File '2' read.
- Time window: 2020-08-07 04:00:00 CEST - 2020-08-07 05:00:00 CEST
- Region: DE
- Batch: 1 of 1
- Signature Info:
verification_key_version: "v1"
verification_key_id: "262"
signature_algorithm: "1.2.840.10045.4.3.2"

Diagnosis Keys:
(none)

Revised Diagnosis Keys:
(none)
Parsing the Diagnosis Key list, counting unique users...
Length: 0 keys (0 without padding)
0 user(s) found.
```