### PR TITLE
Add key count to JSON and Plain Text output

### DIFF
--- a/parse_keys.py
+++ b/parse_keys.py
@@ -76,6 +76,7 @@ print("- Time window: %s - %s" % (get_string_from_datetime(start_timestamp),
                                   get_string_from_datetime(end_timestamp)))
 print("- Region: %s" % dk.get_region())
 print("- Batch: %d of %d" % (dk.get_batch_num(), dk.get_batch_size()))
+print("- # of keys in batch: %d" % len(dk.get_keys()))
 
 for signature_info in dk.get_signature_infos():
     print("- Signature Info:")

--- a/parse_keys_json.py
+++ b/parse_keys_json.py
@@ -27,6 +27,7 @@ json_obj["timeWindowEnd"] = get_string_from_datetime(end_timestamp)
 json_obj["region"] = dk.get_region()
 json_obj["batchNum"] = dk.get_batch_num()
 json_obj["batchCount"] = dk.get_batch_size()
+json_obj["keyCount"] = len(dk.get_keys())
 
 json_obj["signatureInfos"] = dict()
 for signature_info in dk.get_signature_infos():


### PR DESCRIPTION
Regardless of being able to parse the JSON output and extract the number of keys from the array, it's useful to have the key count on the object properties. 

It's specially useful for someone analysing number of keys published per package on a bigger scale. One can simply:
```bash
$ python3 ./parse_keys.py -d /path/to/keys/2020-09-01.zip | grep "# of keys" | sed 's/- # of keys in batch: //g'
> 24033
```